### PR TITLE
Compare tags

### DIFF
--- a/.github/workflows/boat-server-release.yml
+++ b/.github/workflows/boat-server-release.yml
@@ -92,7 +92,6 @@ jobs:
 #          mvn -Pprod jib:build -Dskip.unit.tests=true -Dskip.integration.tests=true -Djib.to.image=${{steps.vars.outputs.image}}:${{steps.vars.outputs.tag}} -Djib.to.auth.username=${{ github.repository }} -Djib.to.auth.password=${{ secrets.GITHUB_TOKEN }}
       - name: Update to next Development version
         run: |
-          cd boat-bay-server
           git config --global user.name 'boatbay-releaser'
           git config --global user.email 'releaser@boat.noreply.github.com'
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}

--- a/.github/workflows/boat-ui-release.yml
+++ b/.github/workflows/boat-ui-release.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           filters: |
             frontend:
-              - 'boat-bay-frontend/**'
+              - 'boat-bay-frontend/src/**'
 
   # JOB to release frontend
   frontend:

--- a/boat-bay-api/pom.xml
+++ b/boat-bay-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.oss.boat.bay</groupId>
         <artifactId>boat-bay</artifactId>
-        <version>0.0.4-SNAPSHOT</version>
+        <version>0.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>boat-bay-api</artifactId>

--- a/boat-bay-client/pom.xml
+++ b/boat-bay-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.oss.boat.bay</groupId>
         <artifactId>boat-bay</artifactId>
-        <version>0.0.4-SNAPSHOT</version>
+        <version>0.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>boat-bay-client</artifactId>

--- a/boat-bay-frontend/pom.xml
+++ b/boat-bay-frontend/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.oss.boat.bay</groupId>
         <artifactId>boat-bay</artifactId>
-        <version>0.0.4-SNAPSHOT</version>
+        <version>0.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>boat-bay-frontend</artifactId>

--- a/boat-bay-server/pom.xml
+++ b/boat-bay-server/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.backbase.oss.boat.bay</groupId>
     <artifactId>boat-bay-server</artifactId>
-    <version>0.0.6-SNAPSHOT</version>
+    <version>0.0.5-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Boat Bay :: Server</name>
 

--- a/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/service/backwardscompatible/BoatBackwardsCompatibleChecker.java
+++ b/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/service/backwardscompatible/BoatBackwardsCompatibleChecker.java
@@ -3,8 +3,11 @@ package com.backbase.oss.boat.bay.service.backwardscompatible;
 import com.backbase.oss.boat.bay.domain.Spec;
 import com.backbase.oss.boat.bay.domain.enumeration.Changes;
 import com.backbase.oss.boat.bay.repository.BoatSpecRepository;
+import com.backbase.oss.boat.bay.util.TagsDiff;
 import com.github.zafarkhaja.semver.Version;
+import io.swagger.v3.oas.models.PathItem;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -64,11 +67,12 @@ public class BoatBackwardsCompatibleChecker {
                     ChangedOpenApi diff = null;
                     try {
                         diff = OpenApiCompare.fromContents(previousOpenAPI, currentOpenAPI);
-                        if (diff.isUnchanged()) {
+                        Map<String, Map<PathItem.HttpMethod, List<String>>> changedTags = TagsDiff.findMissingTags(diff);
+                        if (diff.isUnchanged() && changedTags.isEmpty()) {
                             spec.setChanges(Changes.UNCHANGED);
-                        } else if (diff.isCompatible()) {
+                        } else if (diff.isCompatible() && changedTags.isEmpty()) {
                             spec.setChanges(Changes.COMPATIBLE);
-                        } else if (diff.isIncompatible()) {
+                        } else if (diff.isIncompatible() || !changedTags.isEmpty()) {
                             spec.setChanges(Changes.BREAKING);
                         }
                     } catch (Exception e) {

--- a/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/util/TagsDiff.java
+++ b/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/util/TagsDiff.java
@@ -53,7 +53,7 @@ public class TagsDiff {
                         List<PathItem.HttpMethod> sharedHttpMethods = MapKeyDiff.diff(oldOperationMap, newOperationMap).getSharedKey();
 
                         for (PathItem.HttpMethod method : sharedHttpMethods) {
-                            Optional<List<String>> missingOldTags = extracted(
+                            Optional<List<String>> missingOldTags = compareOldAndNewTags(
                                 oldOperationMap.get(method).getTags(),
                                 newOperationMap.get(method).getTags()
                             );
@@ -67,7 +67,7 @@ public class TagsDiff {
         return missingTags;
     }
 
-    private static Optional<List<String>> extracted(List<String> oldTags, List<String> newTags) {
+    private static Optional<List<String>> compareOldAndNewTags(List<String> oldTags, List<String> newTags) {
         if (oldTags != null) {
             if (newTags != null) {
                 //Remove all common tags

--- a/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/util/TagsDiff.java
+++ b/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/util/TagsDiff.java
@@ -38,7 +38,7 @@ public class TagsDiff {
                 (String url) -> {
                     PathItem oldPathWithAllOperations = oldPaths.get(url);
 
-                    // Normalizing because if spec 1 is /bar/{mypath}/foo  and spec 2 is /bar/{mynewpath}/foo is same
+                    // Normalizing because if spec 1 is /bar/{mypath}/foo and spec 2 is /bar/{mynewpath}/foo, both are same.
                     String normalizeUrl = normalizePath(url);
 
                     //Find the equivalent url in the newPaths

--- a/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/util/TagsDiff.java
+++ b/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/util/TagsDiff.java
@@ -54,6 +54,7 @@ public class TagsDiff {
 
                         // Extract all operations from both urls and process common
                         // NOTE - Goal is to find only missing tags from old specs. Other difference are already calculated
+                        // and in ChangedOpenApi object which will be redeered seperately.
                         Map<PathItem.HttpMethod, Operation> oldOperationMap = oldPathWithAllOperations.readOperationsMap();
                         Map<PathItem.HttpMethod, Operation> newOperationMap = newPathWithAllOperations.readOperationsMap();
                         MapKeyDiff<PathItem.HttpMethod, Operation> operationsDiff = MapKeyDiff.diff(oldOperationMap, newOperationMap);
@@ -67,7 +68,7 @@ public class TagsDiff {
                                 //Remove all common tags
                                 oldTags.removeAll(newTags);
 
-                                //Tags changed in new Spec
+                                //Tags changed in new Spec. Ideally this should be empty.
                                 if (!oldTags.isEmpty()) {
                                     missingTags.put(url, Map.of(method, oldTags));
                                 }

--- a/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/util/TagsDiff.java
+++ b/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/util/TagsDiff.java
@@ -14,6 +14,8 @@ import org.openapitools.openapidiff.core.model.ChangedOpenApi;
 
 public class TagsDiff {
 
+    private TagsDiff() {}
+
     private static final String REGEX_PATH = "\\{([^/]+)\\}";
 
     private static String normalizePath(String path) {
@@ -84,11 +86,6 @@ public class TagsDiff {
         String normalizeUrl = normalizePath(oldPath);
 
         //Find the equivalent url in the newPaths
-        Optional<Map.Entry<String, PathItem>> result = newPaths
-            .entrySet()
-            .stream()
-            .filter(item -> normalizePath(item.getKey()).equals(normalizeUrl))
-            .findAny();
-        return result;
+        return newPaths.entrySet().stream().filter(item -> normalizePath(item.getKey()).equals(normalizeUrl)).findAny();
     }
 }

--- a/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/util/TagsDiff.java
+++ b/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/util/TagsDiff.java
@@ -1,0 +1,81 @@
+package com.backbase.oss.boat.bay.util;
+
+import static org.openapitools.openapidiff.core.utils.Copy.copyMap;
+
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import java.util.*;
+import org.openapitools.openapidiff.core.compare.MapKeyDiff;
+import org.openapitools.openapidiff.core.model.ChangedOpenApi;
+
+public class TagsDiff {
+
+    private static final String REGEX_PATH = "\\{([^/]+)\\}";
+
+    private static String normalizePath(String path) {
+        return path.replaceAll(REGEX_PATH, "{}");
+    }
+
+    public static Paths valOrEmpty(Paths path) {
+        if (path == null) {
+            path = new Paths();
+        }
+        return path;
+    }
+
+    public static Map<String, Map<PathItem.HttpMethod, List<String>>> findMissingTags(ChangedOpenApi changedOpenApi) {
+        //Copy elements to maintain immutability
+        Map<String, PathItem> oldPaths = copyMap(valOrEmpty(changedOpenApi.getOldSpecOpenApi().getPaths()));
+        Map<String, PathItem> newPaths = copyMap(valOrEmpty(changedOpenApi.getNewSpecOpenApi().getPaths()));
+
+        Map<String, Map<PathItem.HttpMethod, List<String>>> missingTags = new HashMap<>();
+
+        //Loop through all Urls
+        oldPaths
+            .keySet()
+            .forEach(
+                (String url) -> {
+                    PathItem oldPathWithAllOperations = oldPaths.get(url);
+
+                    // Normalizing because if spec 1 is /bar/{mypath}/foo  and spec 2 is /bar/{mynewpath}/foo is same
+                    String normalizeUrl = normalizePath(url);
+
+                    //Find the equivalent url in the newPaths
+                    Optional<Map.Entry<String, PathItem>> result = newPaths
+                        .entrySet()
+                        .stream()
+                        .filter(item -> normalizePath(item.getKey()).equals(normalizeUrl))
+                        .findAny();
+
+                    if (result.isPresent()) {
+                        String rightUrl = result.get().getKey();
+                        PathItem newPathWithAllOperations = newPaths.get(rightUrl);
+
+                        // Extract all operations from both urls and process common
+                        // NOTE - Goal is to find only missing tags from old specs. Other difference are already calculated
+                        Map<PathItem.HttpMethod, Operation> oldOperationMap = oldPathWithAllOperations.readOperationsMap();
+                        Map<PathItem.HttpMethod, Operation> newOperationMap = newPathWithAllOperations.readOperationsMap();
+                        MapKeyDiff<PathItem.HttpMethod, Operation> operationsDiff = MapKeyDiff.diff(oldOperationMap, newOperationMap);
+
+                        List<PathItem.HttpMethod> sharedMethods = operationsDiff.getSharedKey();
+
+                        for (PathItem.HttpMethod method : sharedMethods) {
+                            List<String> oldTags = oldOperationMap.get(method).getTags();
+                            List<String> newTags = newOperationMap.get(method).getTags();
+                            if (oldTags != null && newTags != null) {
+                                //Remove all common tags
+                                oldTags.removeAll(newTags);
+
+                                //Tags changed in new Spec
+                                if (!oldTags.isEmpty()) {
+                                    missingTags.put(url, Map.of(method, oldTags));
+                                }
+                            }
+                        }
+                    }
+                }
+            );
+        return missingTags;
+    }
+}

--- a/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/web/views/dashboard/controller/BoatDashboardController.java
+++ b/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/web/views/dashboard/controller/BoatDashboardController.java
@@ -328,7 +328,7 @@ public class BoatDashboardController implements DashboardApi {
         Map<String, Map<PathItem.HttpMethod, List<String>>> changedTags = TagsDiff.findMissingTags(changedOpenApi);
         DiffReportRenderer htmlRender = new DiffReportRenderer();
 
-        return ResponseEntity.ok(htmlRender.render(changedOpenApi));
+        return ResponseEntity.ok(htmlRender.render(changedOpenApi, changedTags));
     }
 
     @Override

--- a/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/web/views/dashboard/controller/BoatDashboardController.java
+++ b/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/web/views/dashboard/controller/BoatDashboardController.java
@@ -7,8 +7,14 @@ import com.backbase.oss.boat.bay.model.*;
 import com.backbase.oss.boat.bay.repository.*;
 import com.backbase.oss.boat.bay.service.lint.BoatSpecLinter;
 import com.backbase.oss.boat.bay.service.statistics.BoatStatisticsCollector;
+import com.backbase.oss.boat.bay.util.TagsDiff;
 import com.backbase.oss.boat.bay.web.views.dashboard.diff.DiffReportRenderer;
 import com.backbase.oss.boat.bay.web.views.dashboard.mapper.BoatDashboardMapper;
+import io.swagger.v3.oas.models.PathItem;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
@@ -29,12 +35,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import tech.jhipster.web.util.PaginationUtil;
-
-import java.math.BigDecimal;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.stream.Collectors;
-
 
 @RestController
 @Transactional
@@ -62,26 +62,23 @@ public class BoatDashboardController implements DashboardApi {
     private static Map<Severity, Integer> severityOrder;
 
     public List<String> getAllEnabledTags() {
-        return tagRepository.findAll(Example.of(new Tag().hide(false))).stream()
-            .map(Tag::getName)
-            .collect(Collectors.toList());
+        return tagRepository.findAll(Example.of(new Tag().hide(false))).stream().map(Tag::getName).collect(Collectors.toList());
     }
 
     public ResponseEntity<List<BoatPortal>> getPortals() {
-
-        List<BoatPortal> portals = boatPortalRepository.findAll().stream()
-            .map(this::mapPortal)
-            .collect(Collectors.toList());
-
+        List<BoatPortal> portals = boatPortalRepository.findAll().stream().map(this::mapPortal).collect(Collectors.toList());
 
         return ResponseEntity.ok(portals);
     }
 
     public ResponseEntity<List<BoatLintRule>> getPortalLintRules(String portalKey) {
-
         Portal portal = getPortal(portalKey);
 
-        List<BoatLintRule> portalLintRules = portal.getLintRules().stream().map(dashboardMapper::mapPortalLintRule).collect(Collectors.toList());
+        List<BoatLintRule> portalLintRules = portal
+            .getLintRules()
+            .stream()
+            .map(dashboardMapper::mapPortalLintRule)
+            .collect(Collectors.toList());
         return ResponseEntity.ok(portalLintRules);
     }
 
@@ -97,40 +94,38 @@ public class BoatDashboardController implements DashboardApi {
         Page<Product> allByPortal = boatProductRepository.findAllByPortal(portal, getPageable(page, size, sort));
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(ServletUriComponentsBuilder.fromCurrentRequest(), allByPortal);
         List<BoatProduct> products = allByPortal.stream().map(this::mapProduct).collect(Collectors.toList());
-        return ResponseEntity.ok()
-            .headers(headers)
-            .body(products);
+        return ResponseEntity.ok().headers(headers).body(products);
     }
 
-
     @Override
-    public ResponseEntity<List<BoatService>> getPortalServices(String portalKey, String productKey, Integer page, Integer size, List<String> sort) {
+    public ResponseEntity<List<BoatService>> getPortalServices(
+        String portalKey,
+        String productKey,
+        Integer page,
+        Integer size,
+        List<String> sort
+    ) {
         Product product = getProduct(portalKey, productKey);
 
         Page<ServiceDefinition> byCapabilityProduct = boatServiceRepository.findByCapabilityProduct(product, getPageable(page, size, sort));
 
         List<BoatService> services = byCapabilityProduct.stream().map(this::mapService).collect(Collectors.toList());
-        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(ServletUriComponentsBuilder.fromCurrentRequest(), byCapabilityProduct);
-        return ResponseEntity.ok()
-            .headers(headers)
-            .body(services);
-
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(
+            ServletUriComponentsBuilder.fromCurrentRequest(),
+            byCapabilityProduct
+        );
+        return ResponseEntity.ok().headers(headers).body(services);
     }
-
 
     private Portal getPortal(String portalKey) {
-        return boatPortalRepository.findByKey(portalKey)
-            .orElseThrow((() -> new ResponseStatusException(HttpStatus.NOT_FOUND)));
+        return boatPortalRepository.findByKey(portalKey).orElseThrow((() -> new ResponseStatusException(HttpStatus.NOT_FOUND)));
     }
 
-    public ResponseEntity<Void> updatePortalLintRule(
-        String portalKey,
-        String lintRuleId,
-        @RequestBody BoatLintRule boatLintRule) {
-
+    public ResponseEntity<Void> updatePortalLintRule(String portalKey, String lintRuleId, @RequestBody BoatLintRule boatLintRule) {
         Portal portal = getPortal(portalKey);
 
-        LintRule lintRule = lintRuleRepository.findById(Long.valueOf(lintRuleId))
+        LintRule lintRule = lintRuleRepository
+            .findById(Long.valueOf(lintRuleId))
             .orElseThrow((() -> new ResponseStatusException(HttpStatus.NOT_FOUND)));
 
         boatSpecRepository.findAll(Example.of(new Spec().portal(portal))).forEach(boatSpecLinter::scheduleLintJob);
@@ -144,54 +139,56 @@ public class BoatDashboardController implements DashboardApi {
 
     @Cacheable(value = BoatCacheManager.PRODUCT_RELEASES)
     public ResponseEntity<List<BoatProductRelease>> getProductReleases(String portalKey, String productKey) {
-
         Product product = getProduct(portalKey, productKey);
 
         List<ProductRelease> productRelease = boatProductReleaseRepository.findAllByProductOrderByReleaseDate(product);
-        List<BoatProductRelease> boatProductReleases = productRelease.stream().map(dashboardMapper::mapBoatProductRelease).collect(Collectors.toList());
+        List<BoatProductRelease> boatProductReleases = productRelease
+            .stream()
+            .map(dashboardMapper::mapBoatProductRelease)
+            .collect(Collectors.toList());
 
         return ResponseEntity.ok(boatProductReleases);
     }
 
     @Cacheable(value = BoatCacheManager.PRODUCT_SPECS)
     public ResponseEntity<List<BoatSpec>> getProductReleaseSpecs(String portalKey, String productKey, String releaseKey) {
-
         Product product = getProduct(portalKey, productKey);
-        ProductRelease productRelease = boatProductReleaseRepository.findByProductAndKey(product, releaseKey).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        ProductRelease productRelease = boatProductReleaseRepository
+            .findByProductAndKey(product, releaseKey)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
 
-        List<BoatSpec> specs = productRelease.getSpecs().stream()
-            .map(this::mapSpec)
-            .collect(Collectors.toList());
+        List<BoatSpec> specs = productRelease.getSpecs().stream().map(this::mapSpec).collect(Collectors.toList());
         return ResponseEntity.ok(specs);
     }
 
     @Cacheable(value = BoatCacheManager.PRODUCT_TAGS)
     public ResponseEntity<List<BoatTag>> getProductTags(String portalKey, String productKey) {
-
         Product product = getProduct(portalKey, productKey);
         List<Spec> specsForProduct = getSpecsForProduct(product);
 
         Map<Tag, Integer> tagCount = new HashMap<>();
 
         for (Spec spec : specsForProduct) {
-
-            spec.getTags().forEach(tag -> {
-                int occurences = tagCount.getOrDefault(tag, 0) + 1;
-                tagCount.put(tag, occurences);
-            });
-
+            spec
+                .getTags()
+                .forEach(
+                    tag -> {
+                        int occurences = tagCount.getOrDefault(tag, 0) + 1;
+                        tagCount.put(tag, occurences);
+                    }
+                );
         }
         List<BoatTag> tags = new ArrayList<>();
-        tagCount.forEach((tag, integer) -> {
-            BoatTag boatTag = dashboardMapper.mapTag(tag);
-            boatTag.setNumberOfOccurrences(integer);
-            tags.add(boatTag);
-
-        });
+        tagCount.forEach(
+            (tag, integer) -> {
+                BoatTag boatTag = dashboardMapper.mapTag(tag);
+                boatTag.setNumberOfOccurrences(integer);
+                tags.add(boatTag);
+            }
+        );
 
         return ResponseEntity.ok(tags);
     }
-
 
     private List<Spec> getSpecsForProduct(Product product) {
         return boatSpecRepository.findAll(boatSpecQuerySpecs.hasProduct(product.getId()));
@@ -199,8 +196,19 @@ public class BoatDashboardController implements DashboardApi {
 
     @Override
     @Cacheable(value = BoatCacheManager.PRODUCT_SPECS)
-    public ResponseEntity<List<BoatSpec>> getPortalSpecs(String portalKey, String productKey, Integer page, Integer size, List<String> sort, List<String> capabilityId, String productReleaseId, List<String> serviceId, String grade, Boolean backwardsCompatible, Boolean changed) {
-
+    public ResponseEntity<List<BoatSpec>> getPortalSpecs(
+        String portalKey,
+        String productKey,
+        Integer page,
+        Integer size,
+        List<String> sort,
+        List<String> capabilityId,
+        String productReleaseId,
+        List<String> serviceId,
+        String grade,
+        Boolean backwardsCompatible,
+        Boolean changed
+    ) {
         Product product = getProduct(portalKey, productKey);
 
         Specification<Spec> specification = boatSpecQuerySpecs.hasProduct(product.getId());
@@ -220,7 +228,8 @@ public class BoatDashboardController implements DashboardApi {
         if (serviceId != null) {
             Specification<Spec> serviceDefinitionSpecification = boatSpecQuerySpecs.hasServiceDefinition(serviceId.get(0));
             for (int i = 1; i < serviceId.size(); i++) {
-                serviceDefinitionSpecification = serviceDefinitionSpecification.or(boatSpecQuerySpecs.hasServiceDefinition(serviceId.get(i)));
+                serviceDefinitionSpecification =
+                    serviceDefinitionSpecification.or(boatSpecQuerySpecs.hasServiceDefinition(serviceId.get(i)));
             }
             specification = specification.and(serviceDefinitionSpecification);
         }
@@ -228,17 +237,11 @@ public class BoatDashboardController implements DashboardApi {
         Page<Spec> all = boatSpecRepository.findAll(specification, getPageable(page, size, sort));
         Page<BoatSpec> boatSpecs = all.map(this::mapSpec);
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(ServletUriComponentsBuilder.fromCurrentRequest(), boatSpecs);
-        return ResponseEntity.ok()
-            .headers(headers)
-            .body(boatSpecs.getContent());
+        return ResponseEntity.ok().headers(headers).body(boatSpecs.getContent());
     }
 
-
     @SuppressWarnings("SuspiciousMethodCalls")
-    public ResponseEntity<BoatLintReport> getLintReportForSpec(String portalKey,
-                                                               String productKey,
-                                                               BigDecimal specId,
-                                                               Boolean refresh) {
+    public ResponseEntity<BoatLintReport> getLintReportForSpec(String portalKey, String productKey, BigDecimal specId, Boolean refresh) {
         Product product = getProduct(portalKey, productKey);
 
         log.info("Get lint report for spec: {} in product: {}", specId, product.getName());
@@ -252,27 +255,31 @@ public class BoatDashboardController implements DashboardApi {
         BoatLintReport lintReport = dashboardMapper.mapReport(specReport);
         lintReport.setOpenApi(spec.getOpenApi());
 
-        lintReport.getViolations()
-            .sort(Comparator.comparing(boatViolation -> boatViolation.getRule().getRuleId()));
+        lintReport.getViolations().sort(Comparator.comparing(boatViolation -> boatViolation.getRule().getRuleId()));
 
-        lintReport.getViolations()
-            .sort(Comparator.comparing(
-                BoatViolation::getSeverity,
-                Comparator.comparingInt(severityIntegerMap::get)));
+        lintReport.getViolations().sort(Comparator.comparing(BoatViolation::getSeverity, Comparator.comparingInt(severityIntegerMap::get)));
 
         return ResponseEntity.ok(lintReport);
     }
 
-
-    public ResponseEntity<Resource> downloadSpec(String portalKey,
-                                                 String productKey,
-                                                 String capabilityKey,
-                                                 String serviceKey,
-                                                 String specKey,
-                                                 String version) {
-
-        Spec spec = boatSpecRepository.findByPortalKeyAndProductKeyAndCapabilityKeyAndServiceDefinitionKeyAndKeyAndVersion(
-            portalKey, productKey, capabilityKey, serviceKey, specKey, version).orElseThrow((() -> new ResponseStatusException(HttpStatus.NOT_FOUND)));
+    public ResponseEntity<Resource> downloadSpec(
+        String portalKey,
+        String productKey,
+        String capabilityKey,
+        String serviceKey,
+        String specKey,
+        String version
+    ) {
+        Spec spec = boatSpecRepository
+            .findByPortalKeyAndProductKeyAndCapabilityKeyAndServiceDefinitionKeyAndKeyAndVersion(
+                portalKey,
+                productKey,
+                capabilityKey,
+                serviceKey,
+                specKey,
+                version
+            )
+            .orElseThrow((() -> new ResponseStatusException(HttpStatus.NOT_FOUND)));
 
         HttpHeaders header = new HttpHeaders();
         header.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + spec.getFilename());
@@ -282,47 +289,66 @@ public class BoatDashboardController implements DashboardApi {
 
         ByteArrayResource openApiBody = new ByteArrayResource(spec.getOpenApi().getBytes(StandardCharsets.UTF_8));
 
-        return ResponseEntity.ok()
+        return ResponseEntity
+            .ok()
             .headers(header)
             .contentLength(spec.getOpenApi().length())
             .contentType(MediaType.valueOf("application/vnd.oai.openapi"))
             .body(openApiBody);
-
     }
 
     @Override
-    public ResponseEntity<BoatSpec> getSpec(String portalKey, String productKey, String capabilityKey, String serviceKey, String specKey, String version) {
-
-        Spec spec = boatSpecRepository.findByPortalKeyAndProductKeyAndCapabilityKeyAndServiceDefinitionKeyAndKeyAndVersion(
-            portalKey, productKey, capabilityKey, serviceKey, specKey, version).orElseThrow((() -> new ResponseStatusException(HttpStatus.NOT_FOUND)));
+    public ResponseEntity<BoatSpec> getSpec(
+        String portalKey,
+        String productKey,
+        String capabilityKey,
+        String serviceKey,
+        String specKey,
+        String version
+    ) {
+        Spec spec = boatSpecRepository
+            .findByPortalKeyAndProductKeyAndCapabilityKeyAndServiceDefinitionKeyAndKeyAndVersion(
+                portalKey,
+                productKey,
+                capabilityKey,
+                serviceKey,
+                specKey,
+                version
+            )
+            .orElseThrow((() -> new ResponseStatusException(HttpStatus.NOT_FOUND)));
 
         BoatSpec body = dashboardMapper.mapBoatSpec(spec);
         body.setOpenApi(spec.getOpenApi());
 
         return ResponseEntity.ok(body);
-
     }
 
-    public ResponseEntity<String> getDiffReport(String portalKey,
-                                                String productKey,
-                                                Integer spec1Id,
-                                                Integer spec2Id) {
+    public ResponseEntity<String> getDiffReport(String portalKey, String productKey, Integer spec1Id, Integer spec2Id) {
         ChangedOpenApi changedOpenApi = getChangedOpenApi(portalKey, productKey, spec1Id, spec2Id);
+        Map<String, Map<PathItem.HttpMethod, List<String>>> changedTags = TagsDiff.findMissingTags(changedOpenApi);
         DiffReportRenderer htmlRender = new DiffReportRenderer();
 
         return ResponseEntity.ok(htmlRender.render(changedOpenApi));
     }
 
-
     @Override
     @Cacheable(value = BoatCacheManager.PRODUCT_CAPABILITIES)
-    public ResponseEntity<List<BoatCapability>> getPortalCapabilities(String portalKey, String productKey, Integer page, Integer size, List<String> sort) {
+    public ResponseEntity<List<BoatCapability>> getPortalCapabilities(
+        String portalKey,
+        String productKey,
+        Integer page,
+        Integer size,
+        List<String> sort
+    ) {
         Product product = getProduct(portalKey, productKey);
 
         Page<Capability> capabilities = boatCapabilityRepository.findByProduct(product, getPageable(page, size, sort));
         Page<BoatCapability> boatCapabilities = capabilities.map(this::mapCapability);
 
-        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(ServletUriComponentsBuilder.fromCurrentRequest(), boatCapabilities);
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(
+            ServletUriComponentsBuilder.fromCurrentRequest(),
+            boatCapabilities
+        );
         return ResponseEntity.ok().headers(headers).body(boatCapabilities.getContent());
     }
 
@@ -345,7 +371,8 @@ public class BoatDashboardController implements DashboardApi {
     }
 
     private Product getProduct(String portalKey, String productKey) {
-        return boatProductRepository.findByKeyAndPortalKey(productKey, portalKey)
+        return boatProductRepository
+            .findByKeyAndPortalKey(productKey, portalKey)
             .orElseThrow((() -> new ResponseStatusException(HttpStatus.NOT_FOUND)));
     }
 
@@ -376,17 +403,17 @@ public class BoatDashboardController implements DashboardApi {
         BoatPortal boatPortal = dashboardMapper.mapBoatPortal(portal);
         boatPortal.setNumberOfCapabilities(boatCapabilityRepository.countByProductPortal(portal));
         boatPortal.setNumberOfServices(boatServiceRepository.countByCapabilityProductPortal(portal));
-        boatLintReportRepository.findDistinctFirstBySpecProductPortalOrderByLintedOn(portal).ifPresent(
-            lintReport -> boatPortal.setLastLintReport(dashboardMapper.mapReportWithoutViolations(lintReport))
-        );
+        boatLintReportRepository
+            .findDistinctFirstBySpecProductPortalOrderByLintedOn(portal)
+            .ifPresent(lintReport -> boatPortal.setLastLintReport(dashboardMapper.mapReportWithoutViolations(lintReport)));
         return boatPortal;
     }
 
     @NotNull
     private BoatProduct mapProduct(Product product) {
-
         BoatProduct boatProduct = dashboardMapper.mapBoatProduct(product);
-        boatLintReportRepository.findDistinctFirstBySpecProductOrderByLintedOn(product)
+        boatLintReportRepository
+            .findDistinctFirstBySpecProductOrderByLintedOn(product)
             .ifPresent(lintReport -> boatProduct.setLastLintReport(dashboardMapper.mapReportWithoutViolations(lintReport)));
         boatProduct.setStatistics(boatStatisticsCollector.collect(product));
         boatProduct.setPortalName(product.getPortal().getName());
@@ -396,14 +423,13 @@ public class BoatDashboardController implements DashboardApi {
 
     @NotNull
     private BoatCapability mapCapability(Capability capability) {
-
         BoatCapability boatCapability = dashboardMapper.mapBoatCapability(capability);
-        boatLintReportRepository.findDistinctFirstBySpecServiceDefinitionCapability(capability)
+        boatLintReportRepository
+            .findDistinctFirstBySpecServiceDefinitionCapability(capability)
             .ifPresent(lintReport -> boatCapability.setLastLintReport(dashboardMapper.mapReportWithoutViolations(lintReport)));
         boatCapability.setStatistics(boatStatisticsCollector.collect(capability));
         return boatCapability;
     }
-
 
     private Pageable getPageable(Integer page, Integer size, List<String> sort) {
         if (page == null || size == null) {
@@ -414,17 +440,16 @@ public class BoatDashboardController implements DashboardApi {
         } else {
             return PageRequest.of(page, size, parseSort(sort));
         }
-
     }
 
     private Sort parseSort(List<String> sortParameters) {
-        List<Sort.Order> orders = sortParameters.stream()
+        List<Sort.Order> orders = sortParameters
+            .stream()
             .map(this::parseSortParameter)
             .filter(order -> !order.getProperty().equals("undefined"))
             .collect(Collectors.toList());
 
         return orders.isEmpty() ? Sort.unsorted() : Sort.by(orders);
-
     }
 
     @NotNull
@@ -446,5 +471,4 @@ public class BoatDashboardController implements DashboardApi {
 
         return Sort.Direction.ASC;
     }
-
 }

--- a/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/web/views/dashboard/diff/DiffReportRenderer.java
+++ b/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/web/views/dashboard/diff/DiffReportRenderer.java
@@ -48,39 +48,33 @@ public class DiffReportRenderer implements Render {
         this.diff = diff;
 
         List<Endpoint> newEndpoints = diff.getNewEndpoints();
-        ContainerTag ol_newEndpoint = ol_newEndpoint(newEndpoints);
+        ContainerTag olNewEndpoint = ol_newEndpoint(newEndpoints);
 
         List<Endpoint> missingEndpoints = diff.getMissingEndpoints();
-        ContainerTag ol_missingEndpoint = ol_missingEndpoint(missingEndpoints);
+        ContainerTag olMissingEndpoint = ol_missingEndpoint(missingEndpoints);
 
         List<Endpoint> deprecatedEndpoints = diff.getDeprecatedEndpoints();
-        ContainerTag ol_deprecatedEndpoint = ol_deprecatedEndpoint(deprecatedEndpoints);
+        ContainerTag olDeprecatedEndpoint = ol_deprecatedEndpoint(deprecatedEndpoints);
 
         List<ChangedOperation> changedOperations = diff.getChangedOperations();
-        ContainerTag ol_changed = ol_changed(changedOperations);
+        ContainerTag olChanged = ol_changed(changedOperations);
 
-        ContainerTag ol_tags = ol_tags(changedTags);
+        ContainerTag olTags = olTags(changedTags);
 
-        return renderHtml(ol_newEndpoint, ol_missingEndpoint, ol_deprecatedEndpoint, ol_changed, ol_tags);
+        return renderHtml(olNewEndpoint, olMissingEndpoint, olDeprecatedEndpoint, olChanged, olTags);
     }
 
-    public String renderHtml(
-        ContainerTag ol_new,
-        ContainerTag ol_miss,
-        ContainerTag ol_deprec,
-        ContainerTag ol_changed,
-        ContainerTag ol_tags
-    ) {
+    public String renderHtml(ContainerTag olNew, ContainerTag olMiss, ContainerTag olDeprec, ContainerTag olChanged, ContainerTag olTags) {
         ContainerTag html = div()
             .withClass("article")
             .with(
-                div().with(h5("What's New"), hr(), ol_new),
-                div().with(h5("What's Deleted"), hr(), ol_miss),
-                div().with(h5("What's Deprecated"), hr(), ol_deprec),
-                div().with(h5("What's Changed"), hr(), ol_changed)
+                div().with(h5("What's New"), hr(), olNew),
+                div().with(h5("What's Deleted"), hr(), olMiss),
+                div().with(h5("What's Deprecated"), hr(), olDeprec),
+                div().with(h5("What's Changed"), hr(), olChanged)
             );
-        if (ol_tags != null) {
-            html.with(div().with(h5("Missing Tags"), hr(), ol_tags));
+        if (olTags != null) {
+            html.with(div().with(h5("Missing Tags"), hr(), olTags));
         }
 
         return html.render();
@@ -148,19 +142,19 @@ public class DiffReportRenderer implements Render {
         return ol;
     }
 
-    private ContainerTag ol_tags(Map<String, Map<PathItem.HttpMethod, List<String>>> changedTags) {
+    private ContainerTag olTags(Map<String, Map<PathItem.HttpMethod, List<String>>> changedTags) {
         ContainerTag ol = ol();
         for (var eachPath : changedTags.entrySet()) {
             String pathUrl = eachPath.getKey();
             for (var eachHttpMethod : eachPath.getValue().entrySet()) {
                 PathItem.HttpMethod httpMethod = eachHttpMethod.getKey();
-                ol.with(li_missingTags(pathUrl, httpMethod.toString(), changedTags.get(pathUrl).get(httpMethod)));
+                ol.with(liMissingTags(pathUrl, httpMethod.toString(), changedTags.get(pathUrl).get(httpMethod)));
             }
         }
         return ol;
     }
 
-    private ContainerTag li_missingTags(String pathUrl, String methodName, List<String> missingTags) {
+    private ContainerTag liMissingTags(String pathUrl, String methodName, List<String> missingTags) {
         return li()
             .with(span(methodName).withClass(methodName))
             .withText(pathUrl)

--- a/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/web/views/dashboard/diff/DiffReportRenderer.java
+++ b/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/web/views/dashboard/diff/DiffReportRenderer.java
@@ -10,23 +10,10 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import j2html.tags.ContainerTag;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.openapitools.openapidiff.core.model.ChangedApiResponse;
-import org.openapitools.openapidiff.core.model.ChangedContent;
-import org.openapitools.openapidiff.core.model.ChangedMediaType;
-import org.openapitools.openapidiff.core.model.ChangedMetadata;
-import org.openapitools.openapidiff.core.model.ChangedOpenApi;
-import org.openapitools.openapidiff.core.model.ChangedOperation;
-import org.openapitools.openapidiff.core.model.ChangedParameter;
-import org.openapitools.openapidiff.core.model.ChangedParameters;
-import org.openapitools.openapidiff.core.model.ChangedResponse;
-import org.openapitools.openapidiff.core.model.ChangedSchema;
-import org.openapitools.openapidiff.core.model.DiffContext;
-import org.openapitools.openapidiff.core.model.DiffResult;
-import org.openapitools.openapidiff.core.model.Endpoint;
+import org.openapitools.openapidiff.core.model.*;
 import org.openapitools.openapidiff.core.output.Render;
 import org.openapitools.openapidiff.core.utils.RefPointer;
 import org.openapitools.openapidiff.core.utils.RefType;
@@ -163,29 +150,21 @@ public class DiffReportRenderer implements Render {
 
     private ContainerTag ol_tags(Map<String, Map<PathItem.HttpMethod, List<String>>> changedTags) {
         ContainerTag ol = ol();
-        changedTags
-            .keySet()
-            .forEach(
-                pathUrl -> {
-                    ContainerTag ul_detail = ul().withClass("detail");
-
-                    changedTags
-                        .get(pathUrl)
-                        .keySet()
-                        .forEach(
-                            method -> {
-                                ul_detail.with(
-                                    ul().with(li().withClass("missing").with(span(changedTags.get(pathUrl).get(method).toString())))
-                                );
-                                ol.with(
-                                    li().with(span(method.toString()).withClass(method.toString())).withText(pathUrl + " ").with(ul_detail)
-                                );
-                            }
-                        );
-                }
-            );
-
+        for (var eachPath : changedTags.entrySet()) {
+            String pathUrl = eachPath.getKey();
+            for (var eachHttpMethod : eachPath.getValue().entrySet()) {
+                PathItem.HttpMethod httpMethod = eachHttpMethod.getKey();
+                ol.with(li_missingTags(pathUrl, httpMethod.toString(), changedTags.get(pathUrl).get(httpMethod)));
+            }
+        }
         return ol;
+    }
+
+    private ContainerTag li_missingTags(String pathUrl, String methodName, List<String> missingTags) {
+        return li()
+            .with(span(methodName).withClass(methodName))
+            .withText(pathUrl)
+            .with(ul().withClass("detail").with(li().with(span(missingTags.toString()))));
     }
 
     private ContainerTag ul_response(ChangedApiResponse changedApiResponse) {

--- a/boat-bay-server/src/test/java/com/backbase/oss/boat/bay/util/TagsDiffTest.java
+++ b/boat-bay-server/src/test/java/com/backbase/oss/boat/bay/util/TagsDiffTest.java
@@ -11,55 +11,48 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.openapitools.openapidiff.core.OpenApiCompare;
 import org.openapitools.openapidiff.core.model.ChangedOpenApi;
-import org.openapitools.openapidiff.core.output.HtmlRender;
 
 @Slf4j
 class TagsDiffTest {
 
     @Test
-    public void test_when_no_changes_to_tag_were_made() {
-        TagsDiff tagsDiff = new TagsDiff();
-
+    void test_when_no_changes_to_tag_were_made() {
         ChangedOpenApi diff = OpenApiCompare.fromLocations(
             getFile("/compare-tags/no-change/pet-store-client-api-v1.yaml"),
             getFile("/compare-tags/no-change/pet-store-client-api-v1_1.yaml")
         );
 
-        Map<String, Map<PathItem.HttpMethod, List<String>>> result = tagsDiff.findMissingTags(diff);
+        Map<String, Map<PathItem.HttpMethod, List<String>>> result = TagsDiff.findMissingTags(diff);
         log.info("test_when_no_changes_to_tag_were_made result {}", result.toString());
-        assertThat(result.size()).isEqualTo(0);
+        assertThat(result).hasSize(0);
     }
 
     @Test
-    public void test_when_one_tag_was_removed() {
-        TagsDiff tagsDiff = new TagsDiff();
-
+    void test_when_one_tag_was_removed() {
         ChangedOpenApi diff = OpenApiCompare.fromLocations(
             getFile("/compare-tags/one-removed/pet-store-client-api-v1.yaml"),
             getFile("/compare-tags/one-removed/pet-store-client-api-v1_1.yaml")
         );
 
-        Map<String, Map<PathItem.HttpMethod, List<String>>> result = tagsDiff.findMissingTags(diff);
+        Map<String, Map<PathItem.HttpMethod, List<String>>> result = TagsDiff.findMissingTags(diff);
         log.info("test_when_one_tag_was_removed result {}", result.toString());
 
-        assertThat(result.size()).isEqualTo(1);
+        assertThat(result).hasSize(1);
         assertThat(result.get("/pet/{petId}")).isNotEmpty();
         assertThat(result.get("/pet/{petId}").get(PathItem.HttpMethod.GET).get(0)).isEqualTo("tag-three");
     }
 
     @Test
-    public void test_when_one_tag_was_removed_and_one_changed() {
-        TagsDiff tagsDiff = new TagsDiff();
-
+    void test_when_one_tag_was_removed_and_one_changed() {
         ChangedOpenApi diff = OpenApiCompare.fromLocations(
             getFile("/compare-tags/one-removed-one-changed/pet-store-client-api-v1.yaml"),
             getFile("/compare-tags/one-removed-one-changed/pet-store-client-api-v1_1.yaml")
         );
 
-        Map<String, Map<PathItem.HttpMethod, List<String>>> result = tagsDiff.findMissingTags(diff);
+        Map<String, Map<PathItem.HttpMethod, List<String>>> result = TagsDiff.findMissingTags(diff);
         log.info("test_when_one_tag_was_removed_and_one_changed result {}", result.toString());
 
-        assertThat(result.size()).isEqualTo(2);
+        assertThat(result).hasSize(2);
 
         assertThat(result.get("/pet")).isNotEmpty();
         assertThat(result.get("/pet").get(PathItem.HttpMethod.POST).get(0)).isEqualTo("tag-two");
@@ -69,18 +62,16 @@ class TagsDiffTest {
     }
 
     @Test
-    public void test_when_all_tags_were_removed() {
-        TagsDiff tagsDiff = new TagsDiff();
-
+    void test_when_all_tags_were_removed() {
         ChangedOpenApi diff = OpenApiCompare.fromLocations(
             getFile("/compare-tags/all-tags-removed/pet-store-client-api-v1.yaml"),
             getFile("/compare-tags/all-tags-removed/pet-store-client-api-v1_1.yaml")
         );
 
-        Map<String, Map<PathItem.HttpMethod, List<String>>> result = tagsDiff.findMissingTags(diff);
+        Map<String, Map<PathItem.HttpMethod, List<String>>> result = TagsDiff.findMissingTags(diff);
         log.info("test_when_all_tags_were_removed result {}", result.toString());
 
-        assertThat(result.size()).isEqualTo(1);
+        assertThat(result).hasSize(1);
 
         assertThat(result.get("/pet/{petId}")).isNotEmpty();
         assertThat(result.get("/pet/{petId}").get(PathItem.HttpMethod.GET).get(0)).isEqualTo("tag-two");
@@ -88,16 +79,15 @@ class TagsDiffTest {
     }
 
     @Test
-    public void renderHtmlTest() {
+    void renderHtmlTest() {
         DiffReportRenderer render = new DiffReportRenderer();
-        TagsDiff tagsDiff = new TagsDiff();
 
         ChangedOpenApi diff = OpenApiCompare.fromLocations(
             getFile("/compare-tags/one-removed-one-changed/pet-store-client-api-v1.yaml"),
             getFile("/compare-tags/one-removed-one-changed/pet-store-client-api-v1_1.yaml")
         );
 
-        Map<String, Map<PathItem.HttpMethod, List<String>>> changedTags = tagsDiff.findMissingTags(diff);
+        Map<String, Map<PathItem.HttpMethod, List<String>>> changedTags = TagsDiff.findMissingTags(diff);
 
         assertThat(render.render(diff, changedTags)).isNotBlank();
     }

--- a/boat-bay-server/src/test/java/com/backbase/oss/boat/bay/util/TagsDiffTest.java
+++ b/boat-bay-server/src/test/java/com/backbase/oss/boat/bay/util/TagsDiffTest.java
@@ -1,0 +1,72 @@
+package com.backbase.oss.boat.bay.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.swagger.v3.oas.models.PathItem;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.openapitools.openapidiff.core.OpenApiCompare;
+import org.openapitools.openapidiff.core.model.ChangedOpenApi;
+
+@Slf4j
+class TagsDiffTest {
+
+    @Test
+    public void test_when_no_changes_to_tag_were_made() {
+        TagsDiff tagsDiff = new TagsDiff();
+
+        ChangedOpenApi diff = OpenApiCompare.fromLocations(
+            getFile("/compare-tags/no-change/pet-store-client-api-v1.yaml"),
+            getFile("/compare-tags/no-change/pet-store-client-api-v1_1.yaml")
+        );
+
+        Map<String, Map<PathItem.HttpMethod, List<String>>> result = tagsDiff.findMissingTags(diff);
+        log.info("test_when_no_changes_to_tag_were_made result {}", result.toString());
+        assertThat(result.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void test_when_one_tag_was_removed() {
+        TagsDiff tagsDiff = new TagsDiff();
+
+        ChangedOpenApi diff = OpenApiCompare.fromLocations(
+            getFile("/compare-tags/one-removed/pet-store-client-api-v1.yaml"),
+            getFile("/compare-tags/one-removed/pet-store-client-api-v1_1.yaml")
+        );
+
+        Map<String, Map<PathItem.HttpMethod, List<String>>> result = tagsDiff.findMissingTags(diff);
+        log.info("test_when_one_tag_was_removed result {}", result.toString());
+
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get("/pet/{petId}")).isNotEmpty();
+        assertThat(result.get("/pet/{petId}").get(PathItem.HttpMethod.GET).get(0)).isEqualTo("tag-three");
+    }
+
+    @Test
+    public void test_when_one_tag_was_removed_and_one_changed() {
+        TagsDiff tagsDiff = new TagsDiff();
+
+        ChangedOpenApi diff = OpenApiCompare.fromLocations(
+            getFile("/compare-tags/one-removed-one-changed/pet-store-client-api-v1.yaml"),
+            getFile("/compare-tags/one-removed-one-changed/pet-store-client-api-v1_1.yaml")
+        );
+
+        Map<String, Map<PathItem.HttpMethod, List<String>>> result = tagsDiff.findMissingTags(diff);
+        log.info("test_when_one_tag_was_removed_and_one_changed result {}", result.toString());
+
+        assertThat(result.size()).isEqualTo(2);
+
+        assertThat(result.get("/pet")).isNotEmpty();
+        assertThat(result.get("/pet").get(PathItem.HttpMethod.POST).get(0)).isEqualTo("tag-two");
+
+        assertThat(result.get("/pet/{petId}")).isNotEmpty();
+        assertThat(result.get("/pet/{petId}").get(PathItem.HttpMethod.GET).get(0)).isEqualTo("tag-three");
+    }
+
+    private String getFile(String glob) {
+        return (new File("src/test/resources").getAbsolutePath() + glob);
+    }
+}

--- a/boat-bay-server/src/test/java/com/backbase/oss/boat/bay/util/TagsDiffTest.java
+++ b/boat-bay-server/src/test/java/com/backbase/oss/boat/bay/util/TagsDiffTest.java
@@ -2,6 +2,7 @@ package com.backbase.oss.boat.bay.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.backbase.oss.boat.bay.web.views.dashboard.diff.DiffReportRenderer;
 import io.swagger.v3.oas.models.PathItem;
 import java.io.File;
 import java.util.List;
@@ -10,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.openapitools.openapidiff.core.OpenApiCompare;
 import org.openapitools.openapidiff.core.model.ChangedOpenApi;
+import org.openapitools.openapidiff.core.output.HtmlRender;
 
 @Slf4j
 class TagsDiffTest {
@@ -64,6 +66,40 @@ class TagsDiffTest {
 
         assertThat(result.get("/pet/{petId}")).isNotEmpty();
         assertThat(result.get("/pet/{petId}").get(PathItem.HttpMethod.GET).get(0)).isEqualTo("tag-three");
+    }
+
+    @Test
+    public void test_when_all_tags_were_removed() {
+        TagsDiff tagsDiff = new TagsDiff();
+
+        ChangedOpenApi diff = OpenApiCompare.fromLocations(
+            getFile("/compare-tags/all-tags-removed/pet-store-client-api-v1.yaml"),
+            getFile("/compare-tags/all-tags-removed/pet-store-client-api-v1_1.yaml")
+        );
+
+        Map<String, Map<PathItem.HttpMethod, List<String>>> result = tagsDiff.findMissingTags(diff);
+        log.info("test_when_all_tags_were_removed result {}", result.toString());
+
+        assertThat(result.size()).isEqualTo(1);
+
+        assertThat(result.get("/pet/{petId}")).isNotEmpty();
+        assertThat(result.get("/pet/{petId}").get(PathItem.HttpMethod.GET).get(0)).isEqualTo("tag-two");
+        assertThat(result.get("/pet/{petId}").get(PathItem.HttpMethod.GET).get(1)).isEqualTo("tag-three");
+    }
+
+    @Test
+    public void renderHtmlTest() {
+        DiffReportRenderer render = new DiffReportRenderer();
+        TagsDiff tagsDiff = new TagsDiff();
+
+        ChangedOpenApi diff = OpenApiCompare.fromLocations(
+            getFile("/compare-tags/one-removed-one-changed/pet-store-client-api-v1.yaml"),
+            getFile("/compare-tags/one-removed-one-changed/pet-store-client-api-v1_1.yaml")
+        );
+
+        Map<String, Map<PathItem.HttpMethod, List<String>>> changedTags = tagsDiff.findMissingTags(diff);
+
+        assertThat(render.render(diff, changedTags)).isNotBlank();
     }
 
     private String getFile(String glob) {

--- a/boat-bay-server/src/test/java/com/backbase/oss/boat/bay/util/TagsDiffTest.java
+++ b/boat-bay-server/src/test/java/com/backbase/oss/boat/bay/util/TagsDiffTest.java
@@ -24,7 +24,7 @@ class TagsDiffTest {
 
         Map<String, Map<PathItem.HttpMethod, List<String>>> result = TagsDiff.findMissingTags(diff);
         log.info("test_when_no_changes_to_tag_were_made result {}", result.toString());
-        assertThat(result).hasSize(0);
+        assertThat(result).isEmpty();
     }
 
     @Test

--- a/boat-bay-server/src/test/resources/compare-tags/all-tags-removed/pet-store-client-api-v1.yaml
+++ b/boat-bay-server/src/test/resources/compare-tags/all-tags-removed/pet-store-client-api-v1.yaml
@@ -1,0 +1,116 @@
+openapi: "3.0.3"
+info:
+  title: Swagger Petstore
+  description: Petstore
+  version: 1.0.0
+  x-icon: petstore
+servers:
+  - description: Prism mock server
+    url: http://localhost:4010
+tags:
+  - name: tag-one
+    description: Everything about your tag-one
+  - name: tag-two
+    description: Everything about your tag-one
+  - name: tag-three
+    description: Everything about your tag-one
+    externalDocs:
+      description: Find out more about our store
+      url: 'http://swagger.io'
+paths:
+  /pet:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      tags:
+        - tag-one
+        - tag-two
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pet/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - tag-two
+        - tag-three
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: 'Delete pet by id'
+      operationId: deletePet
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        type:
+          type: string
+          description: type of pet
+          enum:
+            - Dog
+            - Cat
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/boat-bay-server/src/test/resources/compare-tags/all-tags-removed/pet-store-client-api-v1_1.yaml
+++ b/boat-bay-server/src/test/resources/compare-tags/all-tags-removed/pet-store-client-api-v1_1.yaml
@@ -1,0 +1,149 @@
+openapi: "3.0.3"
+info:
+  title: Swagger Petstore
+  description: Petstore
+  version: 1.1.0
+  x-icon: petstore
+servers:
+  - description: Prism mock server
+    url: http://localhost:4010
+tags:
+  - name: tag-one
+    description: Everything about your tag-one
+  - name: tag-two
+    description: Everything about your tag-one
+  - name: tag-three
+    description: Everything about your tag-one
+    externalDocs:
+      description: Find out more about our store
+      url: 'http://swagger.io'
+paths:
+  /pet:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      tags:
+        - tag-one
+        - tag-two
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pet/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: 'Delete pet by id'
+      operationId: deletePet
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - tag-one
+        - tag-three
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        type:
+          type: string
+          description: type of pet
+          enum:
+            - Dog
+            - Cat
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/boat-bay-server/src/test/resources/compare-tags/no-change/pet-store-client-api-v1.yaml
+++ b/boat-bay-server/src/test/resources/compare-tags/no-change/pet-store-client-api-v1.yaml
@@ -1,0 +1,116 @@
+openapi: "3.0.3"
+info:
+  title: Swagger Petstore
+  description: Petstore
+  version: 1.0.0
+  x-icon: petstore
+servers:
+  - description: Prism mock server
+    url: http://localhost:4010
+tags:
+  - name: tag-one
+    description: Everything about your tag-one
+  - name: tag-two
+    description: Everything about your tag-one
+  - name: tag-three
+    description: Everything about your tag-one
+    externalDocs:
+      description: Find out more about our store
+      url: 'http://swagger.io'
+paths:
+  /pet:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      tags:
+        - tag-one
+        - tag-two
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pet/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - tag-two
+        - tag-three
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: 'Delete pet by id'
+      operationId: deletePet
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        type:
+          type: string
+          description: type of pet
+          enum:
+            - Dog
+            - Cat
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/boat-bay-server/src/test/resources/compare-tags/no-change/pet-store-client-api-v1_1.yaml
+++ b/boat-bay-server/src/test/resources/compare-tags/no-change/pet-store-client-api-v1_1.yaml
@@ -1,0 +1,152 @@
+openapi: "3.0.3"
+info:
+  title: Swagger Petstore
+  description: Petstore
+  version: 1.1.0
+  x-icon: petstore
+servers:
+  - description: Prism mock server
+    url: http://localhost:4010
+tags:
+  - name: tag-one
+    description: Everything about your tag-one
+  - name: tag-two
+    description: Everything about your tag-one
+  - name: tag-three
+    description: Everything about your tag-one
+    externalDocs:
+      description: Find out more about our store
+      url: 'http://swagger.io'
+paths:
+  /pet:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      tags:
+        - tag-one
+        - tag-two
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pet/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - tag-two
+        - tag-three
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: 'Delete pet by id'
+      operationId: deletePet
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - tag-one
+        - tag-three
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        type:
+          type: string
+          description: type of pet
+          enum:
+            - Dog
+            - Cat
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/boat-bay-server/src/test/resources/compare-tags/one-removed-one-changed/pet-store-client-api-v1.yaml
+++ b/boat-bay-server/src/test/resources/compare-tags/one-removed-one-changed/pet-store-client-api-v1.yaml
@@ -1,0 +1,116 @@
+openapi: "3.0.3"
+info:
+  title: Swagger Petstore
+  description: Petstore
+  version: 1.0.0
+  x-icon: petstore
+servers:
+  - description: Prism mock server
+    url: http://localhost:4010
+tags:
+  - name: tag-one
+    description: Everything about your tag-one
+  - name: tag-two
+    description: Everything about your tag-one
+  - name: tag-three
+    description: Everything about your tag-one
+    externalDocs:
+      description: Find out more about our store
+      url: 'http://swagger.io'
+paths:
+  /pet:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      tags:
+        - tag-one
+        - tag-two
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pet/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - tag-two
+        - tag-three
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: 'Delete pet by id'
+      operationId: deletePet
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        type:
+          type: string
+          description: type of pet
+          enum:
+            - Dog
+            - Cat
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/boat-bay-server/src/test/resources/compare-tags/one-removed-one-changed/pet-store-client-api-v1_1.yaml
+++ b/boat-bay-server/src/test/resources/compare-tags/one-removed-one-changed/pet-store-client-api-v1_1.yaml
@@ -1,0 +1,151 @@
+openapi: "3.0.3"
+info:
+  title: Swagger Petstore
+  description: Petstore
+  version: 1.1.0
+  x-icon: petstore
+servers:
+  - description: Prism mock server
+    url: http://localhost:4010
+tags:
+  - name: tag-one
+    description: Everything about your tag-one
+  - name: tag-two
+    description: Everything about your tag-one
+  - name: tag-three
+    description: Everything about your tag-one
+    externalDocs:
+      description: Find out more about our store
+      url: 'http://swagger.io'
+paths:
+  /pet:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      tags:
+        - tag-one
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pet/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - tag-one
+        - tag-two
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: 'Delete pet by id'
+      operationId: deletePet
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - tag-one
+        - tag-three
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        type:
+          type: string
+          description: type of pet
+          enum:
+            - Dog
+            - Cat
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/boat-bay-server/src/test/resources/compare-tags/one-removed/pet-store-client-api-v1.yaml
+++ b/boat-bay-server/src/test/resources/compare-tags/one-removed/pet-store-client-api-v1.yaml
@@ -1,0 +1,116 @@
+openapi: "3.0.3"
+info:
+  title: Swagger Petstore
+  description: Petstore
+  version: 1.0.0
+  x-icon: petstore
+servers:
+  - description: Prism mock server
+    url: http://localhost:4010
+tags:
+  - name: tag-one
+    description: Everything about your tag-one
+  - name: tag-two
+    description: Everything about your tag-one
+  - name: tag-three
+    description: Everything about your tag-one
+    externalDocs:
+      description: Find out more about our store
+      url: 'http://swagger.io'
+paths:
+  /pet:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      tags:
+        - tag-one
+        - tag-two
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pet/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - tag-two
+        - tag-three
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: 'Delete pet by id'
+      operationId: deletePet
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        type:
+          type: string
+          description: type of pet
+          enum:
+            - Dog
+            - Cat
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/boat-bay-server/src/test/resources/compare-tags/one-removed/pet-store-client-api-v1_1.yaml
+++ b/boat-bay-server/src/test/resources/compare-tags/one-removed/pet-store-client-api-v1_1.yaml
@@ -1,0 +1,151 @@
+openapi: "3.0.3"
+info:
+  title: Swagger Petstore
+  description: Petstore
+  version: 1.1.0
+  x-icon: petstore
+servers:
+  - description: Prism mock server
+    url: http://localhost:4010
+tags:
+  - name: tag-one
+    description: Everything about your tag-one
+  - name: tag-two
+    description: Everything about your tag-one
+  - name: tag-three
+    description: Everything about your tag-one
+    externalDocs:
+      description: Find out more about our store
+      url: 'http://swagger.io'
+paths:
+  /pet:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      tags:
+        - tag-one
+        - tag-two
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pet/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - tag-two
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: 'Delete pet by id'
+      operationId: deletePet
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - tag-one
+        - tag-three
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        type:
+          type: string
+          description: type of pet
+          enum:
+            - Dog
+            - Cat
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.backbase.oss.boat.bay</groupId>
     <artifactId>boat-bay</artifactId>
-    <version>0.0.4-SNAPSHOT</version>
+    <version>0.0.5-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Boat Bay ::  Parent</name>
 


### PR DESCRIPTION
Logic to Parse through all tags in each URL-operations and check if there is a [missing tag](https://backbase.atlassian.net/wiki/spaces/GUIL/pages/2380988882/Open+API#Tags).  The logic is sort of a util method that is called from 2 places: 

1. Once when you upload a new spec (postman, maven plugin).  (BoatBackwardsCompatibleChecker class comes into picture. )
2. Everytime you compare 2 specs from boat-bay UI. (BoatDashboardController#getDiffReport comes in picture).

How will it look in UI:

![image](https://user-images.githubusercontent.com/950278/134362526-59921bc8-6db1-4cbb-a6cf-ebd8f979176d.png)

The output is rendered in HTML as a 5th row:
![image](https://user-images.githubusercontent.com/950278/134462797-2c40697f-abf7-4a87-90f2-057ad58c43e7.png)

The difference pop up (no changes here, it just compare lines)
![image](https://user-images.githubusercontent.com/950278/134363373-e0c10b5b-9819-42dc-aae9-72e6cd98f605.png)


NOTE - Some lines are due to formatting changes because of the github pre-commit action.

NOTE - tags matching is case-sensitive. Just using the removeAll. 