### PR TITLE
Repeat upload fix

### DIFF
--- a/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/web/views/dashboard/controller/BoatUploadController.java
+++ b/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/web/views/dashboard/controller/BoatUploadController.java
@@ -159,14 +159,7 @@ public class BoatUploadController implements BoatMavenPluginApi {
             spec = existing;
             log.info("Spec {} already uploaded, updating with changes and re-linting", spec.getKey());
         } else {
-            throw new BadRequestAlertException(
-                "This spec," +
-                spec.getKey() +
-                ", has already been uploaded, this upload is not from a" +
-                " project under development and so will be rejected",
-                "SPEC",
-                "duplicateSpec"
-            );
+            log.info("Spec {} already uploaded, adding a new product release version {} ", spec.getKey(), requestBody.getVersion());
         }
         return spec;
     }

--- a/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/web/views/dashboard/controller/BoatUploadController.java
+++ b/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/web/views/dashboard/controller/BoatUploadController.java
@@ -159,7 +159,19 @@ public class BoatUploadController implements BoatMavenPluginApi {
             spec = existing;
             log.info("Spec {} already uploaded, updating with changes and re-linting", spec.getKey());
         } else {
-            log.info("Spec {} already uploaded, adding a new product release version {} ", spec.getKey(), requestBody.getVersion());
+            if (!spec.getOpenApi().equals(existing.getOpenApi())) {
+                String message =
+                    "This spec," +
+                    spec.getKey() +
+                    ", has already been uploaded, this upload is not from a" +
+                    " project under development and so will be rejected";
+                log.warn(message);
+                throw new BadRequestAlertException(message, "SPEC", "duplicateSpec");
+            }
+            //Only Update maven version
+            existing.setMvnVersion(requestBody.getVersion());
+            spec = existing;
+            log.info("Spec {} already uploaded, adding a new service release version {} ", spec.getKey(), requestBody.getVersion());
         }
         return spec;
     }


### PR DESCRIPTION
Scenario: Upload via maven plugin

A spec of service is updated and uploaded via boat-plugin. Let's say at that time, the service version is `7.1.0-SNAPSHOT`. The spec get uploaded and is seen in Boat bay dropdown as semversion - `7.1.0-SNAPSHOT`.
As a next step, the service is released for internal testing to `7.1.0`. At this time the boat-maven-plugin again runs to upload again and faile with following exception:
```
[ERROR] BoatBay error :: [400 Bad Request] during [POST] to [http://localhost:8080/api/boat/portals/backbase/boat-maven-plugin/pet-store-bom/upload] [BoatMavenPluginApi#uploadSpec(String,String,UploadRequestBody)]: [{"entityName":"SPEC","errorKey":"duplicateSpec","type":"https://www.jhipster.tech/problem/problem-with-message","title":"This spec,pet-store-client-api, has already been uploaded, this upload is not from a project under development and so will be rejected","status":400,"message":"error.duplicateSpec","params":"SPEC"}]
```

This PR fixes that to fail only if the contents of the specs are changed during this. Else, the existing specs add a new service version of `7.1.0`. 

Its a bit tricky to remove old version, but maybe we don't want to, as in most of the cases specs will rarely change but the service around it will change many time during a single/multiple relases.  