### PR TITLE
source cannot be mapped to one capability

### DIFF
--- a/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/source/SpecSourceResolver.java
+++ b/boat-bay-server/src/backbase/java/com/backbase/oss/boat/bay/source/SpecSourceResolver.java
@@ -230,9 +230,6 @@ public class SpecSourceResolver {
                 .findByProductAndKey(spec.getProduct(), key)
                 .orElseGet(() -> createCapabilityForSpecWithKey(spec, key));
             log.debug("Assigning capability: {} to spec: {}", capability.getName(), spec.getName());
-            if (source.getCapability() == null) {
-                source.setCapability(capability);
-            }
             spec.setCapability(capability);
         }
     }


### PR DESCRIPTION
Source is can be bb-bom which has many sub-boms (capabilities), so it cannot be mapped to just one.
Source can also be a capability that can have many sub-boms too.